### PR TITLE
show what an acropolis indexer could look like

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +219,95 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -548,6 +648,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,7 +736,9 @@ name = "scooper-v2"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
+ "futures",
  "hex",
  "minicbor 2.1.1",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,9 @@ repository = "https://github.com/rrruko/scooper-v2"
 
 [dependencies]
 anyhow = "1"
+async-trait = "0.1"
 clap = { version = "4.5.41", features = ["derive"] }
+futures = "0.3"
 hex = "0.4.3"
 minicbor = { version = "2.1.1", features = ["alloc", "derive"] }
 num-bigint = "0.4.6"

--- a/src/acropolis.rs
+++ b/src/acropolis.rs
@@ -1,90 +1,254 @@
 // Everything in this file is a mock interface for what Acropolis can provide.
-#![allow(unused)]
 use std::sync::Arc;
 
 use anyhow::Result;
 
-
 pub mod core {
+    #![allow(unused)]
+    use anyhow::bail;
+    use async_trait::async_trait;
+    use pallas_network::miniprotocols::Point;
+    use tokio::task;
+
     use crate::BlockHash;
 
     use super::*;
 
     pub struct Process {
-
+        modules: Vec<Box<dyn Module>>
     }
 
     impl Process {
         pub fn create() -> Self {
-            Self {}
+            Self { modules: vec![] }
         }
-        pub fn register<T: Module>(&mut self, module: T) {}
-        pub async fn run(&self) -> Result<()> {
+        pub fn register<T: Module>(&mut self, module: T) {
+            self.modules.push(Box::new(module));
+        }
+        pub async fn run(self) -> Result<()> {
+            let context = Arc::new(Context {});
+            for mut module in self.modules {
+                module.init(context.clone()).await?;
+            }
             Ok(())
         }
     }
 
-    pub enum Message {
+    pub enum AcropolisMessage {
+        SyncFrom(Point),
+        NewTx(BlockInfo, Vec<u8>),
+        Rollback(BlockInfo),
+    }
 
+    pub struct Subscription {}
+    impl Subscription {
+        pub async fn read(&mut self) -> Result<AcropolisMessage> {
+            let tx = "84a300d90102818258203e28562ebb6f9a777b28f154877c960f9ad5f850e05cf1d761f481c0390badc7000182a300581d6003c0b0797dd49a8549986c3c21c910b75cbe3a6d4e1318872a96763a011a002625a0028201d8185822d87a9f581cc279a3fb3b4e62bbc78e288783b58045d4ae82a18867d8352d02775aff82583900c279a3fb3b4e62bbc78e288783b58045d4ae82a18867d8352d02775a121fd22e0b57ac206fefc763f8bfa0771919f5218b40691eea4514d0821b0000003625048409a1581c45df5f274b8950b512b08d10656864958659c4ecf3ffad092ef63024a144555344720c021a00029ac5a0f5f6";
+            let tx = hex::decode(tx).unwrap();
+            Ok(AcropolisMessage::NewTx(BlockInfo { slot: 0, hash: BlockHash(vec![]) }, tx))
+        }
     }
 
     pub struct Context {
+    
+    }
 
+    impl Context {
+        pub fn run<T, F>(&self, func: F) -> task::JoinHandle<T>
+        where 
+            T: Send + 'static,
+            F: Future<Output = T> + Send + 'static,
+        {
+            tokio::spawn(func)
+        }
+
+        pub async fn publish(&self, topic: &str, message: AcropolisMessage) -> Result<()> {
+            Ok(())
+        }
+
+        pub async fn subscribe(&self, topic: &str) -> Result<Subscription> {
+            Ok(Subscription {  })
+        }
     }
 
     pub struct BlockInfo {
-        pub slot: u8,
+        pub slot: u64,
         pub hash: BlockHash,
     }
 
-    pub trait Module {
-        fn name() -> String;
-        async fn init(&self, context: Arc<Context>) -> Result<()>;
+    #[async_trait]
+    pub trait Module: Send + Sync + 'static {
+        fn name(&self) -> String;
+        async fn init(&mut self, context: Arc<Context>) -> Result<()>;
     }
 }
 
 pub mod indexer {
-    use std::collections::HashMap;
+    use std::{cmp::Ordering, collections::HashMap};
 
+    use async_trait::async_trait;
+    use futures::{StreamExt, stream::FuturesUnordered};
     use pallas_network::miniprotocols::Point;
     use pallas_traverse::MultiEraTx;
 
-    use crate::acropolis::core::{BlockInfo, Module};
+    use crate::acropolis::core::{AcropolisMessage, BlockInfo, Module};
 
     use super::*;
 
-    pub trait ManagedIndex: Send + 'static {
+    #[derive(Debug, Clone)]
+    pub struct Cursor {
+        pub name: String,
+        pub point: Point,
+    }
+
+    pub trait CursorStore: Send + Sync + 'static {
+        fn load(&self) -> impl Future<Output = Result<Vec<Cursor>>> + Send;
+        fn save(&mut self, cursors: &[Cursor]) -> impl Future<Output = Result<()>> + Send;
+    }
+
+    pub struct InMemoryCursorStore {
+        cursors: Vec<Cursor>,
+    }
+    impl InMemoryCursorStore {
+        pub fn new(cursors: Vec<Cursor>) -> Self {
+            Self { cursors }
+        }
+    }
+    impl CursorStore for InMemoryCursorStore {
+        async fn load(&self) -> Result<Vec<Cursor>> {
+            Ok(self.cursors.clone())
+        }
+
+        async fn save(&mut self, cursors: &[Cursor]) -> Result<()> {
+            self.cursors = cursors.to_vec();
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    pub trait ManagedIndex: Send + Sync + 'static {
         fn name(&self) -> String;
+
+        async fn handle_onchain_tx(&mut self, info: &BlockInfo, tx: &MultiEraTx) -> Result<()> {
+            let _ = (info, tx);
+            Ok(())
+        }
+        async fn handle_rollback(&mut self, info: &BlockInfo) -> Result<()> {
+            let _ = info;
+            Ok(())
+        }
     }
 
-    pub trait ManagedChainIndex: ManagedIndex {
-        async fn handle_onchain_tx(&mut self, info: &BlockInfo, tx: &MultiEraTx) -> Result<()>;
-        async fn handle_rollback(&mut self, info: &BlockInfo) -> Result<()>;
+    struct IndexWrapper {
+        name: String,
+        index: Box<dyn ManagedIndex>,
+        tip: Point,
+        force_restart: bool,
     }
 
-    pub struct ChainIndexer {
-        indexes: HashMap<String, Box<dyn ManagedIndex>>,
+    pub struct ChainIndexer<CS: CursorStore> {
+        indexes: HashMap<String, IndexWrapper>,
+        cursor_store: Option<CS>,
     }
 
-    impl ChainIndexer {
-        pub fn new() -> Self {
+    impl<CS: CursorStore> ChainIndexer<CS> {
+        pub fn new(cursors: CS) -> Self {
             Self {
                 indexes: HashMap::new(),
+                cursor_store: Some(cursors),
             }
         }
 
+        /// Begin managing an index.
+        /// If the index doesn't already exist, it will start indexing from `start`.
+        /// If it does, it will start from wherever it began before, unless `force_restart` is passed.
         pub fn add_index<M: ManagedIndex>(&mut self, index: M, start: Point, force_restart: bool) {
-            self.indexes.insert(index.name(), Box::new(index));
+            let name = index.name();
+            if self.indexes.insert(name.clone(), IndexWrapper {
+                name,
+                index: Box::new(index),
+                tip: start,
+                force_restart,
+            }).is_some() {
+                panic!("adding same index twice");
+            }
         }
     }
 
-    impl Module for ChainIndexer {
-        fn name() -> String {
+    #[async_trait]
+    impl<CS: CursorStore> Module for ChainIndexer<CS> {
+        fn name(&self) -> String {
             "chain-indexer".into()
         }
 
-        async fn init(&self, context: Arc<core::Context>) -> Result<()> {
+        async fn init(&mut self, context: Arc<core::Context>) -> Result<()> {
+            let mut blocks = context.subscribe("blocks").await?;
+            let mut indexes = std::mem::take(&mut self.indexes);
+            let mut cursor_store = self.cursor_store.take().unwrap();
+
+            context.clone().run(async move {
+                let should_fetch_cursors = indexes.values().any(|i| !i.force_restart);
+                if should_fetch_cursors {
+                    let cursors = cursor_store.load().await.expect("could not fetch cursors");
+                    for cursor in cursors {
+                        let Some(index) = indexes.get_mut(&cursor.name) else {
+                            continue;
+                        };
+                        if !index.force_restart {
+                            index.tip = cursor.point;
+                        }
+                    }
+                }
+                let first_point = indexes.values().map(|i| &i.tip).min_by(|l, r| compare_points(&l, &r)).cloned().unwrap_or(Point::Origin);
+                context.publish("sync-from", AcropolisMessage::SyncFrom(first_point)).await.expect("could not start sync");
+                while let Ok(message) = blocks.read().await {
+                    match message {
+                        AcropolisMessage::NewTx(info, tx) => {
+                            let tx = MultiEraTx::decode(&tx).expect("invalid tx");
+                            let tx = &tx;
+                            let at = Point::Specific(info.slot, info.hash.0.to_vec());
+                            process_message(indexes.values_mut(), at, |x| x.handle_onchain_tx(&info, tx)).await;
+                        }
+                        AcropolisMessage::Rollback(info) => {
+                            let at = Point::Specific(info.slot, info.hash.0.to_vec());
+                            process_message(indexes.values_mut(), at, |x| x.handle_rollback(&info)).await;
+                        }
+                        _ => {}
+                    }
+                    let cursors = indexes.values().map(|i| Cursor { name: i.name.clone(), point: i.tip.clone() }).collect::<Vec<_>>();
+                    cursor_store.save(&cursors).await.expect("couldn't save cursors");
+                }
+            });
             Ok(())
         }
+    }
+
+    async fn process_message<'a, F, Fut>(indexes: impl Iterator<Item = &'a mut IndexWrapper>, at: Point, f: F)
+    where
+        F: Fn(&'a mut dyn ManagedIndex) -> Fut,
+        Fut: Future<Output = Result<()>>,
+    {
+        let mut fut = FuturesUnordered::new();
+        for index in indexes {
+            let this_is_next = index.tip.slot_or_default() == at.slot_or_default().saturating_sub(1);
+            if this_is_next {
+                fut.push(async {
+                    match f(index.index.as_mut()).await {
+                        Ok(()) => {
+                            index.tip = at.clone();
+                        }
+                        Err(e) => {
+                            eprintln!("index {} failed at {:?}: {e:#}", index.name, index.tip);
+                        }
+                    }
+                });
+            }
+        }
+        while fut.next().await.is_some() {
+        }
+    }
+
+    fn compare_points<'a, 'b>(lhs: &'a Point, rhs: &'b Point) -> Ordering {
+        lhs.slot_or_default().cmp(&rhs.slot_or_default())
     }
 }


### PR DESCRIPTION
Sketch out some sample code for what an Acropolis-backed indexer could look like.

The indexer would track several independent indexes. The interface to an index looks like this:

```rs
// Managed indexes are written in an "event handler" style.
// They react to a stream of events, starting at a configured point on the chain.
// Each index can be somewhere different on-chain, so they should be granular.
#[async_trait]
pub trait ManagedIndex: Send + Sync + 'static {
    fn name(&self) -> String;

    // Called when a new TX has arrived on-chain.
    async fn handle_onchain_tx(&mut self, info: &BlockInfo, tx: &MultiEraTx) -> Result<()> {
        // This method can update a database, or a mutex-locked in-memory map, or publish messages to the rest of the system,
        // or whatever. It's async and it's allowed to be long-running.
        let _ = (info, tx);
        // These indexes are fallible. If an index fails, we'll stop updating it, but keep running other indexes.
        // Could make sense to build a retry in too, in case the issue is just a fallible DB
        Ok(())
    }

    // Called when a block has rolled back.
    async fn handle_rollback(&mut self, info: &BlockInfo) -> Result<()> {
        let _ = info;
        Ok(())
    }
}
```

We'd build one of these "indexes" for each set of data we cared to track in the system. The acropolis module can send updates them as they arrive.

The chain indexer itself would be an Acropolis module, but one with an imperative interface which we could use to set it up. The rest of the scooper doesn't need to use the Acropolis message bus or anything, this module would run in-process so we could just use mutexes and channels and all that.
```rs
let mut indexer = ChainIndexer::new(InMemoryCursorStore::new(vec![]));
let starting_point = match args.command {
    Commands::SyncFromOrigin => Point::Origin,
    Commands::SyncFromPoint{ slot, block_hash } => Point::Specific(slot, block_hash.0)
};
let force_rebuild = false;
indexer.add_index(PoolIndex::new(), starting_point.clone(), force_rebuild);
indexer.add_index(OrderIndex::new(), starting_point.clone(), force_rebuild);

let mut process = Process::create();
process.register(indexer);
process.run().await.unwrap();
```

Each index has a "cursor" tracking how far it is on the chain. If we have new sets of data which we want to index, we can create a new index for them, and let that index build itself while the rest of the application chugs along. Different indexes can start at different points on-chain, so if we introduce e.g. a new type of pool we don't have to search for it starting from the Alonzo era.

